### PR TITLE
Couldn't find a `pages` directory error on Getting Started page

### DIFF
--- a/content/1-basics/1-getting-started.js
+++ b/content/1-basics/1-getting-started.js
@@ -70,7 +70,7 @@ Then open the "package.json" in the hello-next directory and add the following N
   }
 }
 ~~~
-
+Create an empty "pages" directory under the project root.
 Now everything is ready. Run the following command to start the dev server:
 
 ~~~sh


### PR DESCRIPTION
I had "Couldn't find a `pages` directory. Please create one under the project root" error on `npm run dev` step (Mac).
Added one more step to avoid this issue.