### PR TITLE
Fixing example: Fetching Batman Shows

### DIFF
--- a/content/1-basics/7-fetching-data-for-pages.js
+++ b/content/1-basics/7-fetching-data-for-pages.js
@@ -77,7 +77,7 @@ const Index = (props) => (
   <Layout>
     <h1>Batman TV Shows</h1>
     <ul>
-      {props.shows.map(({show}) => (
+      {props.shows.map((show) => (
         <li key={show.id}>
           <Link as={\`/p/\${show.id}\`} href={\`/post?id=\${show.id}\`}>
             <a>{show.name}</a>


### PR DESCRIPTION
Removing unnecessary object deconstruction in map.