### PR TITLE
Fix deployment to now by configuring lambda size

### DIFF
--- a/content/1-basics/9-deploying-a-nextjs-app.js
+++ b/content/1-basics/9-deploying-a-nextjs-app.js
@@ -160,7 +160,11 @@ Then, create a now.json file in the root of your project with the following cont
 {
   "version": 2,
   "builds": [
-    { "src": "package.json", "use": "@now/next" }
+    {
+      "src": "package.json",
+      "use": "@now/next",
+      "config": { "maxLambdaSize": "50mb" }
+    }
   ]
 }
 ~~~


### PR DESCRIPTION
Before this change now would error when deploying because it has a 5mb Lambda size and this demo ends up being a lot larger than that.

Note: This would probably benefit from an explanation of how this 50mb now limit isn't a restricting on nextjs apps (or at least I would as a beginner!) The error I got said the demo was was 35mb when I tried to deploy it, so it's not clear to me how I'd deploy something that wasn't a toy to Now. Regardless, this PR at least makes it work again.